### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This project is no longer being maintained as of March 2026.
+
 ## Running Locally
 
 This project uses yarn workspaces to manage scripts and dependencies. If you do not have yarn installed you can install it by running


### PR DESCRIPTION
## Summary
- Adds a deprecation notice to the top of the README indicating the project is no longer maintained as of March 2026

## Context
- Part of [DX-926](https://ably.atlassian.net/browse/DX-926) to deprecate and archive old ably-labs projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DX-926]: https://ably.atlassian.net/browse/DX-926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ